### PR TITLE
Correction du bug pour quitter avec Ctrl+Q

### DIFF
--- a/src/pyromaths/interface.py
+++ b/src/pyromaths/interface.py
@@ -334,9 +334,7 @@ class Ui_MainWindow(object):
         #============================================================
         #    Raccourcis clavier
         #============================================================
-        keyQuit = QtGui.QShortcut("Ctrl+Q", MainWindow)
-        QtCore.QObject.connect(keyQuit, QtCore.SIGNAL("triggered()"), QtGui.qApp,
-                                                                 QtCore.SLOT("quit()"))
+        self.actionQuitter.setShortcut('Ctrl+Q')
 
         #============================================================
         #    Actions des boutons et menus


### PR DESCRIPTION
Cette correction marche sous linux, pas de raison que ça ne fonctionne pas pour les autres